### PR TITLE
Migrate from Mosquitto/Alpine base image to Ubuntu LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,27 @@
 FROM ubuntu:20.04
 LABEL maintainer="Egidio Caprino <egidio.caprino@gmail.com>"
 
-# Mosquitto
+ENV DEBIAN_FRONTEND="noninteractive" \
+  username="" \
+  password=""
 
-ENV username ""
-ENV password ""
+RUN apt-get --yes update \
+  && apt-get --yes install --no-install-recommends mosquitto python3 python3-paho-mqtt python3-numpy netcat wget software-properties-common sudo gpg-agent \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
+  && wget --quiet --output-document - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+  && add-apt-repository --yes ppa:timescale/timescaledb-ppa \
+  && apt-get --yes update \
+  && apt-get --yes install --no-install-recommends timescaledb-postgresql-12 \
+  && mkdir /opt/openeew \
+  && rm /etc/mosquitto/mosquitto.conf \
+  && touch /etc/mosquitto/mosquitto.conf \
+  && apt-get --yes remove wget software-properties-common gpg-agent \
+  && apt-get --yes autoremove \
+  && apt-get --yes clean \
+  && rm --recursive --force /var/lib/apt/lists/*
 
-ENV DEBIAN_FRONTEND "noninteractive"
-
-RUN apt-get --yes update
-RUN apt-get --yes install mosquitto python3 python3-paho-mqtt python3-numpy netcat
-
-RUN mkdir /opt/openeew
 COPY scripts/detection.py scripts/trigger.py /opt/openeew/
-
-RUN rm /etc/mosquitto/mosquitto.conf
-RUN touch /etc/mosquitto/mosquitto.conf
-
 COPY detector /usr/sbin/detector
 RUN chmod +x /usr/sbin/detector
-
-# TimescaleDB
-
-RUN apt-get --yes update
-RUN apt-get --yes install wget software-properties-common sudo
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
-RUN wget --quiet --output-document - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN apt-get --yes update
-RUN add-apt-repository --yes ppa:timescale/timescaledb-ppa
-RUN apt-get --yes update
-RUN apt-get --yes install timescaledb-postgresql-12
 
 CMD ["/usr/sbin/detector"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM eclipse-mosquitto:1.6.10
+FROM ubuntu:20.04
 LABEL maintainer="Egidio Caprino <egidio.caprino@gmail.com>"
 
 ENV username ""
 ENV password ""
 
-RUN apk update
-RUN apk add python3 py3-paho-mqtt py3-numpy
+RUN apt-get --yes update
+RUN apt-get --yes install mosquitto python3 python3-paho-mqtt python3-numpy netcat
 
 RUN mkdir /opt/openeew
 COPY scripts/detection.py scripts/trigger.py /opt/openeew/
 
-RUN rm /mosquitto/config/mosquitto.conf
-RUN touch /mosquitto/config/mosquitto.conf
+RUN rm /etc/mosquitto/mosquitto.conf
+RUN touch /etc/mosquitto/mosquitto.conf
 
 COPY detector /usr/sbin/detector
 RUN chmod +x /usr/sbin/detector

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM ubuntu:20.04
 LABEL maintainer="Egidio Caprino <egidio.caprino@gmail.com>"
 
+# Mosquitto
+
 ENV username ""
 ENV password ""
+
+ENV DEBIAN_FRONTEND "noninteractive"
 
 RUN apt-get --yes update
 RUN apt-get --yes install mosquitto python3 python3-paho-mqtt python3-numpy netcat
@@ -15,5 +19,16 @@ RUN touch /etc/mosquitto/mosquitto.conf
 
 COPY detector /usr/sbin/detector
 RUN chmod +x /usr/sbin/detector
+
+# TimescaleDB
+
+RUN apt-get --yes update
+RUN apt-get --yes install wget software-properties-common sudo
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
+RUN wget --quiet --output-document - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN apt-get --yes update
+RUN add-apt-repository --yes ppa:timescale/timescaledb-ppa
+RUN apt-get --yes update
+RUN apt-get --yes install timescaledb-postgresql-12
 
 CMD ["/usr/sbin/detector"]

--- a/detector
+++ b/detector
@@ -2,6 +2,11 @@
 
 set -em
 
+timescaledb-tune --quiet --yes
+service postgresql start
+# @todo set up database
+echo "🚀 PostgreSQL with TimescaleDB is ready"
+
 if [ -n "${username}" ] && [ -n "${password}" ]; then
   echo "🔑 Using authentication"
   touch /opt/openeew/mosquitto_passwords

--- a/detector
+++ b/detector
@@ -3,14 +3,15 @@
 set -em
 
 if [ -n "${username}" ] && [ -n "${password}" ]; then
-  echo "Using authentication"
-  touch /mosquitto/config/passwords
-  mosquitto_passwd -b /mosquitto/config/passwords "${username}" "${password}"
-  echo "password_file /mosquitto/config/passwords" >> /mosquitto/config/mosquitto.conf
+  echo "🔑 Using authentication"
+  touch /opt/openeew/mosquitto_passwords
+  mosquitto_passwd -b /opt/openeew/mosquitto_passwords "${username}" "${password}"
+  echo "password_file /opt/openeew/mosquitto_passwords" >> /etc/mosquitto/conf.d/openeew.conf
 else
-  echo "Not using authentication"
+  echo "⚠ Not using authentication"
 fi
 
-mosquitto --config-file /mosquitto/config/mosquitto.conf &
+service mosquitto start
 timeout 1m sh -c "until nc -z 127.0.0.1 1883; do sleep 1; done"
+echo "🚀 Mosquitto is ready"
 python3 /opt/openeew/detection.py --username "${username}" --password "${password}"


### PR DESCRIPTION
We couldn't install TimescaleDB on the previous Alpine based image. For this reason our new Docker image is now based on Ubuntu and it provides both PostgreSQL with TimescaleDB and Mosquitto.

The simulation scripts works as before ✅