### PR TITLE
fix(docker): add check for avoiding double initialization

### DIFF
--- a/detector
+++ b/detector
@@ -2,21 +2,34 @@
 
 set -em
 
+initialized_check_file="/opt/openeew/.initialized"
+
 su - postgres -c "PGDATA='/var/lib/postgresql/data' postgres" &
 timeout 1m sh -c "until nc -z 127.0.0.1 5432; do sleep 1; done"
-# @todo set up database
 echo "🚀 PostgreSQL with TimescaleDB is ready"
-
-if [ -n "${username}" ] && [ -n "${password}" ]; then
-  echo "🔑 Using authentication"
-  touch /opt/openeew/mosquitto_passwords
-  mosquitto_passwd -b /opt/openeew/mosquitto_passwords "${username}" "${password}"
-  echo "password_file /opt/openeew/mosquitto_passwords" >> /opt/openeew/mosquitto.conf
-else
-  echo "⚠ Not using authentication"
-fi
 
 mosquitto -c /opt/openeew/mosquitto.conf -d
 timeout 1m sh -c "until nc -z 127.0.0.1 1883; do sleep 1; done"
 echo "🚀 Mosquitto is ready"
+
+if [ -f "${initialized_check_file}" ]; then
+  echo "✅ Already initialized, skipping initialization"
+else
+  echo "⏲ Initializing..."
+
+  if [ -n "${username}" ] && [ -n "${password}" ]; then
+    echo "🔑 Using authentication"
+    touch /opt/openeew/mosquitto_passwords
+    mosquitto_passwd -b /opt/openeew/mosquitto_passwords "${username}" "${password}"
+    echo "password_file /opt/openeew/mosquitto_passwords" >> /opt/openeew/mosquitto.conf
+  else
+    echo "⚠ Not using authentication"
+  fi
+
+  # @todo set up database
+
+  touch "${initialized_check_file}"
+  echo "✅ Initialized"
+fi
+
 python3 /opt/openeew/detection.py --username "${username}" --password "${password}"


### PR DESCRIPTION
We need to perform some initialization tasks once. Now the `detector` script will touch the `/opt/openeew/.initialized` file once initialized and won't perform those tasks when that file already exists. In this way we can restart the container safely.

Closes #16 