### PR TITLE
Adding a build, push and deploy action for Pull Requests

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -31,3 +31,27 @@ jobs:
           k8s-cluster-namespace: ${{ secrets.K8S_CLUSTER_NAMESPACE }}
           registry-hostname: us.icr.io
 
+  db-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Turnstyle ensures that this job only runs one at a time in this repository
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses : call-for-code/build-push-deploy@main
+        with:
+          cloud-api-key: ${{ secrets.IBM_CLOUD_API_KEY }}
+          cloud-resource-group: OpenEEW-Infra
+          cloud-region: us-south
+          deployment-name: openeew-detection-db-test
+          github-sha: ${{ github.sha }}
+          icr-namespace: ${{ secrets.ICR_NAMESPACE }}
+          image-name: detection-db-gha
+          k8s-cluster-name: ${{ secrets.K8S_CLUSTER_NAME }}
+          k8s-cluster-namespace: ${{ secrets.K8S_CLUSTER_NAMESPACE }}
+          registry-hostname: us.icr.io
+          working-directory: "database/"

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses : call-for-code/build-push-deploy@main
+      - uses: call-for-code/build-push-deploy@main
         with:
           cloud-api-key: ${{ secrets.IBM_CLOUD_API_KEY }}
           cloud-resource-group: OpenEEW-Infra
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses : call-for-code/build-push-deploy@main
+      - uses: call-for-code/build-push-deploy@main
         with:
           cloud-api-key: ${{ secrets.IBM_CLOUD_API_KEY }}
           cloud-resource-group: OpenEEW-Infra

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -1,0 +1,33 @@
+name: Pull Request Build, Push and Deploy
+
+on:
+  # Execute on every pull request to the master branch
+  pull_request_target:
+    branches:
+      - master
+
+jobs:
+  mqtt-detection-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Turnstyle ensures that this job only runs one at a time in this repository
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses : call-for-code/build-push-deploy@main
+        with:
+          cloud-api-key: ${{ secrets.IBM_CLOUD_API_KEY }}
+          cloud-resource-group: OpenEEW-Infra
+          cloud-region: us-south
+          deployment-name: openeew-detection-mqtt-test
+          github-sha: ${{ github.sha }}
+          icr-namespace: ${{ secrets.ICR_NAMESPACE }}
+          image-name: detection-mqtt-gha
+          k8s-cluster-name: ${{ secrets.K8S_CLUSTER_NAME }}
+          k8s-cluster-namespace: ${{ secrets.K8S_CLUSTER_NAMESPACE }}
+          registry-hostname: us.icr.io
+


### PR DESCRIPTION
This action will perform a docker build, push to IBM Cloud registry, and set the image for our Kubernetes deployment. Both the MQTT/Detection and PSQL containers will go through the same process in separate, parallel jobs.

Additionally, I am utilizing the turnstyle action that restricts specific github actions to one build at a time. So this file and its jobs will only execute one at a time. Any pull request that is opened while a build has already started, will have to wait until the previous build is complete. The waiting period is about ~5 minutes at the moment. 

