### PR TITLE
main->v1 to avoid future breakage

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: call-for-code/build-push-deploy@main
+      - uses: call-for-code/build-push-deploy@v1
         with:
           cloud-api-key: ${{ secrets.IBM_CLOUD_API_KEY }}
           cloud-resource-group: OpenEEW-Infra


### PR DESCRIPTION
The call for code team is making changes to the call-for-code/build-push-deploy action. Converting to v1 over main will allow this repo to continue to function the same. 

When the changes are settled in the call-for-code/build-push-deploy action, we'll bring those changes into this repo.